### PR TITLE
Couchbase Lite optimisations based on fp_type filtering

### DIFF
--- a/Source/API/CBLDatabase.h
+++ b/Source/API/CBLDatabase.h
@@ -45,6 +45,13 @@ typedef BOOL (^CBLFilterBlock) (CBLSavedRevision* revision, NSDictionary* params
 /** The number of documents in the database. */
 @property (readonly) NSUInteger documentCount;
 
+/** Dictionary view name -> target_fp_types
+ Only those documents whose "fp_type" property is equal to one in target_fp_types will be
+ passed to the map block and indexed. This can speed up indexing.
+ Just like the map block, this property is not persistent; it needs to be set at runtime before
+ the view is queried. And if its value changes, the view's version also needs to change. */
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSArray<NSString *> *> *docTypes;
+
 /** The latest sequence number used.
     Every new revision is assigned a new sequence number, so this property increases monotonically
     as changes are made to the database. It can be used to check whether the database has changed

--- a/Source/API/CBLDatabase.m
+++ b/Source/API/CBLDatabase.m
@@ -59,7 +59,7 @@ static id<CBLFilterCompiler> sFilterCompiler;
 
 
 @synthesize manager=_manager, unsavedModelsMutable=_unsavedModelsMutable;
-@synthesize path=_path, name=_name, isOpen=_isOpen, encryptionKey=_encryptionKey;
+@synthesize path=_path, name=_name, isOpen=_isOpen, encryptionKey=_encryptionKey, docTypes = _docTypes;
 
 
 - (instancetype) initWithPath: (NSString*)path

--- a/Source/API/CBLView.h
+++ b/Source/API/CBLView.h
@@ -50,6 +50,9 @@ id CBLTextKey(NSString* text);
 /** The optional reduce function, which aggregates together multiple rows. */
 @property (readonly) CBLReduceBlock reduceBlock;
 
+/** The document fp_type property values this view is filtered to (nil if none.) */
+@property (readonly) NSString *documentType;
+
 /** Defines a view's functions.
     The view's definition is given as an Objective-C block (or NULL to delete the view). The body of the block should call the 'emit' block (passed in as a paramter) for every key/value pair it wants to write to the view.
     Since the function itself is obviously not stored in the database (only a unique string idenfitying it), you must re-define the view on every launch of the app! If the database needs to rebuild the view but the function hasn't been defined yet, it will fail and the view will be empty, causing weird problems later on.

--- a/Source/API/CBLView.h
+++ b/Source/API/CBLView.h
@@ -50,9 +50,6 @@ id CBLTextKey(NSString* text);
 /** The optional reduce function, which aggregates together multiple rows. */
 @property (readonly) CBLReduceBlock reduceBlock;
 
-/** The document fp_type property values this view is filtered to (nil if none.) */
-@property (readonly) NSString *documentType;
-
 /** Defines a view's functions.
     The view's definition is given as an Objective-C block (or NULL to delete the view). The body of the block should call the 'emit' block (passed in as a paramter) for every key/value pair it wants to write to the view.
     Since the function itself is obviously not stored in the database (only a unique string idenfitying it), you must re-define the view on every launch of the app! If the database needs to rebuild the view but the function hasn't been defined yet, it will fail and the view will be empty, causing weird problems later on.
@@ -70,6 +67,10 @@ id CBLTextKey(NSString* text);
     See -setMapBlock:reduceBlock:version: for more details. */
 - (BOOL) setMapBlock: (CBLMapBlock)mapBlock
              version: (NSString*)version                            __attribute__((nonnull(1,2)));
+
+- (void)setDocumentTypes:(NSArray<NSString *> *)docTypes;
+
+- (NSArray<NSString *> *)getDocumentTypes;
 
 /** Is the view's index currently out of date? */
 @property (readonly) BOOL stale;

--- a/Source/API/CBLView.m
+++ b/Source/API/CBLView.m
@@ -116,6 +116,22 @@
 }
 
 
+- (void)setDocumentTypes:(NSArray<NSString *> *)docTypes {
+    if (!self.database.docTypes) {
+        self.database.docTypes = [NSMutableDictionary dictionary];
+    }
+    self.database.docTypes[self.name] = docTypes;
+}
+
+
+- (NSArray<NSString *> *)getDocumentTypes {
+    if (!self.database.docTypes) {
+        self.database.docTypes = [NSMutableDictionary dictionary];
+    }
+    return self.database.docTypes[self.name];
+}
+
+
 - (BOOL) stale {
     return self.lastSequenceIndexed < _weakDB.lastSequenceNumber;
 }

--- a/Source/CBLDatabase+Internal.h
+++ b/Source/CBLDatabase+Internal.h
@@ -190,6 +190,10 @@ extern const CBLChangesOptions kDefaultCBLChangesOptions;
 
 - (CBL_Revision*) getParentRevision: (CBL_Revision*)rev;
 
+/** Checks whether DB already contains docs without doc_type column. 
+    In this case we should disable doc_type optimisation. */
+- (BOOL)hasDataWithoutFpType;
+
 /** Returns an array of CBL_Revisions in reverse chronological order,
     starting with the given revision. */
 - (NSArray*) getRevisionHistory: (CBL_Revision*)rev;

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -38,6 +38,9 @@ NSString* const CBL_DatabaseChangesNotification = @"CBLDatabaseChanges";
 NSString* const CBL_DatabaseWillCloseNotification = @"CBL_DatabaseWillClose";
 NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDeleted";
 
+NSString* const  CBL_HasFpTypesEnabledKey = @"HAS_DATA_WITHOUT_FP_TYPE";
+NSString* const  CBL_HasFpTypesConfigFileName = @"has-fp-types-config.plist";
+
 #define kDocIDCacheSize 1000
 
 #define kSQLiteBusyTimeout 5.0 // seconds
@@ -93,7 +96,8 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
     return CBLRemoveFileIfExists(dbPath, outError)
         && CBLRemoveFileIfExists([dbPath stringByAppendingString: @"-wal"], outError)
         && CBLRemoveFileIfExists([dbPath stringByAppendingString: @"-shm"], outError)
-        && CBLRemoveFileIfExists([self attachmentStorePath: dbPath], outError);
+        && CBLRemoveFileIfExists([self attachmentStorePath: dbPath], outError)
+        && CBLRemoveFileIfExists([self getConfigFilePath], outError);
 }
 
 
@@ -267,7 +271,7 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
     BOOL isNew = (dbVersion == 0);
     if (isNew && ![self initialize: @"BEGIN TRANSACTION" error: outError])
         return NO;
-
+    
     if (dbVersion < 1) {
         // First-time initialization:
         // (Note: Declaring revs.sequence as AUTOINCREMENT means the values will always be
@@ -434,6 +438,12 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
         PRAGMA user_version = 12";
         if (![self initialize:sql error: outError]) {
             return NO;
+        }
+        
+        NSUInteger docCount = [self documentCount];
+        if (docCount) {
+            //do not use target_fp_types in views when there are already any docs saved in revs table without doc_type set
+            [self setDataWithoutFpType:YES];
         }
         dbVersion = 12;
     }
@@ -701,8 +711,51 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
 }
 
 
-#pragma mark - GETTING DOCUMENTS:
+#pragma mark - HELPERS
+#pragma mark - Public
 
+- (BOOL)hasDataWithoutFpType {
+    NSString *configFilePath = [self.class getConfigFilePath];
+    BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:configFilePath];
+    return exists;
+}
+
+#pragma mark - PRIVATE
+
++ (NSString *)getConfigFilePath {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsPath = [paths objectAtIndex:0];
+    NSString *configFilePath = [documentsPath stringByAppendingPathComponent:@"db"];
+    NSString *configFilename = [configFilePath stringByAppendingPathComponent:CBL_HasFpTypesConfigFileName];
+    return configFilename;
+}
+
+
+- (void)setDataWithoutFpType:(BOOL)hasData {
+    NSString *configFilePath = [self.class getConfigFilePath];
+    NSDictionary<NSString *, NSString *> *config = @{CBL_HasFpTypesEnabledKey : hasData ? @"YES" : @"NO"};
+    [config writeToFile:configFilePath atomically:YES];
+    BOOL success = [self addSkipBackupAttributeToItemAtPath:configFilePath];
+    LogTo(CBLDatabase, @"%d: File with fp_type setting is written: ", success);
+}
+
+
+- (BOOL)addSkipBackupAttributeToItemAtPath:(NSString *)filePathString
+{
+    NSURL* URL= [NSURL fileURLWithPath: filePathString];
+    assert([[NSFileManager defaultManager] fileExistsAtPath: [URL path]]);
+    
+    NSError *error = nil;
+    BOOL success = [URL setResourceValue: [NSNumber numberWithBool: YES]
+                                  forKey: NSURLIsExcludedFromBackupKey error: &error];
+    if(!success){
+        NSLog(@"Error excluding %@ from backup %@", [URL lastPathComponent], error);
+    }
+    return success;
+}
+
+
+#pragma mark - GETTING DOCUMENTS:
 
 - (NSUInteger) documentCount {
     NSUInteger result = NSNotFound;

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -421,12 +421,23 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
     if (dbVersion < 11) {
         // Version 10: Add another index
         NSString* sql = @"CREATE INDEX revs_cur_deleted ON revs(current,deleted); \
-                          PRAGMA user_version = 11";
+        PRAGMA user_version = 11";
         if (![self initialize: sql error: outError])
             return NO;
         dbVersion = 11;
     }
-
+    
+    if (dbVersion < 12) {
+        //Version 11: Add column fp_type
+        NSString * const sql = @"\
+        ALTER TABLE revs ADD COLUMN doc_type TEXT;\
+        PRAGMA user_version = 12";
+        if (![self initialize:sql error: outError]) {
+            return NO;
+        }
+        dbVersion = 12;
+    }
+    
     if (isNew && ![self initialize: @"END TRANSACTION" error: outError])
         return NO;
 

--- a/Source/CBLDatabase+Internal.m
+++ b/Source/CBLDatabase+Internal.m
@@ -428,7 +428,7 @@ NSString* const CBL_DatabaseWillBeDeletedNotification = @"CBL_DatabaseWillBeDele
     }
     
     if (dbVersion < 12) {
-        //Version 11: Add column fp_type
+        //Version 11: Add column doc_type
         NSString * const sql = @"\
         ALTER TABLE revs ADD COLUMN doc_type TEXT;\
         PRAGMA user_version = 12";

--- a/Source/CBLView+Internal.m
+++ b/Source/CBLView+Internal.m
@@ -267,8 +267,8 @@ static inline NSString* toJSONString(__unsafe_unretained id object ) {
                 inserted++;
         };
         
-        BOOL checkDocTypes = [self getDocumentTypes] != nil && [self getDocumentTypes].count > 0;
-
+        BOOL checkDocTypes = [self getDocumentTypes] != nil && [self getDocumentTypes].count > 0 && ![self.database hasDataWithoutFpType];
+        
         NSMutableString *sql = 	[@"SELECT revs.doc_id, sequence, docid, revid, json, "
                                  "no_attachments, deleted, doc_type "
                                  "FROM revs, docs "
@@ -434,8 +434,8 @@ static inline NSString* toJSONString(__unsafe_unretained id object ) {
         
         CFAbsoluteTime updateIndexEnd = CFAbsoluteTimeGetCurrent();
         
-        LogTo(View, @"...Finished re-indexing view %@ to sequence=%lld (total %u, deleted %u, added %u), took %3.3fsec",
-              _name, dbMaxSequence, total, deleted, inserted, (updateIndexEnd - updateIndexStart));
+        LogTo(View, @"...Finished re-indexing view %@ to sequence=%lld (total %u, deleted %u, added %u), took %3.3fsec, fp_type is used: %d",
+              _name, dbMaxSequence, total, deleted, inserted, (updateIndexEnd - updateIndexStart), checkDocTypes);
         return kCBLStatusOK;
     }];
     


### PR DESCRIPTION
**DO NOT MERGE: Just for review purposes**

Basically we should add an ability for Couchbase views to index only a particular type of document, as indicated by its type property. Issue describing these changes in details is [here](https://github.com/Spotme/spotme3-mobile-ios/issues/1012). You can find related microbenchmarks data and statistics there as well. 
FYI currently Couchbase uses lazy approach for view indexing, but in the upstream repo they added support for eager view re-indexing, hence we have some discrepancies.